### PR TITLE
correct versioninfo in __init__.py to 1.3.0

### DIFF
--- a/netbox_otp_plugin/__init__.py
+++ b/netbox_otp_plugin/__init__.py
@@ -15,7 +15,7 @@ class OTPPluginConfig(PluginConfig):
     name = 'netbox_otp_plugin'
     verbose_name = 'OTP Login'
     description = 'OTP Login plugin'
-    version = '1.2.0'
+    version = '1.3.0'
     author = 'Andrey Shalashov'
     author_email = 'avshalashov@yandex.ru'
     min_version = '4.0.0'


### PR DESCRIPTION
versioninfo is wrong so plugin reports wrong version inside netbox, corrected from 1.2.0 to 1.3.0