### PR TITLE
Support for Netbox 4.2.x

### DIFF
--- a/netbox_otp_plugin/__init__.py
+++ b/netbox_otp_plugin/__init__.py
@@ -19,7 +19,7 @@ class OTPPluginConfig(PluginConfig):
     author = 'Andrey Shalashov'
     author_email = 'avshalashov@yandex.ru'
     min_version = '4.0.0'
-    max_version = '4.1.99'
+    max_version = '4.2.99'
     django_apps = [
         'django_otp',
         'django_otp.plugins.otp_totp',


### PR DESCRIPTION
Fix for https://github.com/k1nky/netbox-otp-plugin/issues/20

Raises the max_version for Netbox 4.2.x compatibility.

Tested and running in dev and production, with no issues observed otherwise.