### PR TITLE
Fixing docker version schema and Netbox version 4.3 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Two-factor authentication for [NetBox](https://github.com/netbox-community/netbo
 
 | NetBox Version| Plugin Version|
 |---------------|---------------|
+| 4.3           | >= 1.3.3      |
 | 4.2           | >= 1.3.2      |
 | 4.1           | >= 1.3.0      |
 | 4.0           | >= 1.1.0      |

--- a/netbox_otp_plugin/__init__.py
+++ b/netbox_otp_plugin/__init__.py
@@ -15,11 +15,11 @@ class OTPPluginConfig(PluginConfig):
     name = 'netbox_otp_plugin'
     verbose_name = 'OTP Login'
     description = 'OTP Login plugin'
-    version = '1.3.2'
+    version = '1.3.3'
     author = 'Andrey Shalashov'
     author_email = 'avshalashov@yandex.ru'
     min_version = '4.0.0'
-    max_version = '4.2.99'
+    max_version = '4.3.99'
     django_apps = [
         'django_otp',
         'django_otp.plugins.otp_totp',

--- a/netbox_otp_plugin/__init__.py
+++ b/netbox_otp_plugin/__init__.py
@@ -43,7 +43,7 @@ class OTPPluginConfig(PluginConfig):
         # making any changes in the original settings.py
         setattr(netbox_settings, 'OTP_TOTP_ISSUER', user_config.get('issuer'))
 
-        parsed_netbox_version = tuple(map(int, netbox_version.split('.')))
+        parsed_netbox_version = tuple(map(int, netbox_version.split('-')[0].split('.')))
         # the AUTH_EXEMPT_PATHS setting has been removed since NetBox v4.1.0
         if parsed_netbox_version < (4, 1, 0):
             # the plugin login URL must be exempt from authentication

--- a/netbox_otp_plugin/templatetags/otp_login_helpers.py
+++ b/netbox_otp_plugin/templatetags/otp_login_helpers.py
@@ -7,5 +7,5 @@ register = template.Library()
 def is_version_greater(value, target):
     """ Returns true if `value` is greater than or equal to `target`.
     """
-    version = lambda s: list(map(int, s.split('.')))    # noqa: E731
+    version = lambda s: list(map(int, s.split('-')[0].split('.')))    # noqa: E731
     return version(value) >= version(target)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='netbox_otp_plugin',
-    version='1.3.2',
+    version='1.3.3',
     description='OTP Login NetBox plugin',
     url='https://github.com/k1nky/netbox-otp-plugin',
     author='Andrey Shalashov',


### PR DESCRIPTION
Inspired by https://github.com/k1nky/netbox-otp-plugin/compare/master and some adjustments, this should fix #26 and #27. 